### PR TITLE
Changed New-AzOperationalInsightsWorkspace SKU parameter from Standard to PerNode

### DIFF
--- a/azure_arc_sqlsrv_jumpstart/gcp/winsrv/terraform/scripts/sql.ps1.tmpl
+++ b/azure_arc_sqlsrv_jumpstart/gcp/winsrv/terraform/scripts/sql.ps1.tmpl
@@ -83,7 +83,7 @@ $Location = "${location}"
 Get-AzResourceGroup -Name $resourceGroup -ErrorAction Stop -Verbose
 
 # Create the workspace
-New-AzOperationalInsightsWorkspace -Location $Location -Name $WorkspaceName -Sku Standard -ResourceGroupName $resourceGroup -Verbose
+New-AzOperationalInsightsWorkspace -Location $Location -Name $WorkspaceName -Sku PerNode -ResourceGroupName $resourceGroup -Verbose
 
 Write-Host "Enabling Log Analytics Solutions"
 $Solutions = "Security", "Updates", "SQLAssessment"


### PR DESCRIPTION
Standard Log Analytics Workspace SKUs are deprecated, hence changed the SKU parameter for New-AzOperationalInsightsWorkspace to PerNode